### PR TITLE
Update lisflood conda environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: lisflood
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu


### PR DESCRIPTION
This change removes the defaults channel from environment.yml so that it is compatible with ECMWF systems (see issue https://github.com/ec-jrc/lisflood-code/issues/184).

Merge request for seedfd_develop branch.

Ran the lisflood tests for seedfd_develop branch using updated environment and all tests completed successfully.