### PR TITLE
Fix LISFLOOD Errors when no lakes or reservoirs in the domain.

### DIFF
--- a/src/lisflood/global_modules/checkers.py
+++ b/src/lisflood/global_modules/checkers.py
@@ -21,10 +21,11 @@ import os
 import inspect
 import warnings
 
+from pcraster.operations import boolean
 import numpy as np
 
 from .errors import LisfloodError, LisfloodWarning
-from .add1 import loadmap, loadsetclone
+from .add1 import loadmap, loadsetclone, compressArray
 from ..hydrological_modules import HydroModule
 from ..hydrological_modules import (surface_routing, evapowater, snow, routing, leafarea, inflow, waterlevel,
                                     waterbalance, wateruse, waterabstraction, lakes, riceirrigation, indicatorcalc,
@@ -39,6 +40,12 @@ def lakes_present(lake_type):
     MaskMap = loadsetclone('MaskMap')  # need to define mask map to use loadmap
     LakeSitesC = loadmap(sites_dict[lake_type])
     LakeSitesC[LakeSitesC < 1] = 0
+
+    # Get rid of any lakes/reservoirs that are not part of the channel network
+    IsChannelPcr = boolean(loadmap('Channels', pcr=True))
+    IsChannel = np.bool8(compressArray(IsChannelPcr))
+    LakeSitesC[IsChannel == 0] = 0
+
     LakeSitesCC = np.compress(LakeSitesC > 0, LakeSitesC)
     if LakeSitesCC.size == 0:
         present = False


### PR DESCRIPTION
When running LISFLOOD over the SEED-FD domains there are errors for the domains that do not contain lakes/reservoirs due to missing expected input files. This is only a problem for warm starts.

This change adds a check to `checkers.py` so that if there are no lakes or reservoirs present then the input file check will not run for lakes/reservoirs.

The lisflood code already handles domains without lakes or reservoirs within the `hydrological_modules/lakes.py` and `hydrological_modules/reservoir.py` scripts so this deals with switching off the options in the model settings. This extra check just deals with the errors that happen before this stage when running checks on input files for model restarts.

The same logic that is used in `hydrological_modules/lakes.py` and `hydrological_modules/reservoir.py`, for determining where a lake/reservoir is present, is used in this new change to `checkers.py`.

Tests carried out:
* lisflood-code/tests run with pytest. All 73 tests passed (fast and slow tests).
* tested in longflow suite. Ran lisflood for the Juba-Shebelle basin and it successfully ran the model including warmstart/restart.