### PR TITLE
Add scipy to environment for running DA for SEED-FD.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -181,6 +181,7 @@ dependencies:
     - pytz==2022.1
     - pyyaml==6.0
     - rasterio==1.2.10
+    - scipy==1.7.3
     - six==1.16.0
     - soupsieve==2.3.2.post1
     - toml==0.10.2


### PR DESCRIPTION
Update to environment file to add scipy. This is required in the lisflood run task for SEED-FD Data Assimilation.
The suite has been tested with the new environment and runs as expected.